### PR TITLE
docs: Correct label mapping and add oco git configuration instructions

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -30,7 +30,7 @@ jobs:
               'feat': 'feature',
               'feature': 'feature',
               'improvement': 'enhancement',
-              'doc': 'documentation',
+              'docs': 'documentation',
               'readme': 'documentation',
               'chore': 'chore',
               'bump': 'dependencies',

--- a/docs/source/development/git.md
+++ b/docs/source/development/git.md
@@ -561,6 +561,7 @@ oco config set OCO_API_KEY=xxx
 ```bash
 oco config set OCO_GITPUSH=false # 关闭自动 push
 oco config set OCO_ONE_LINE_COMMIT=true # 单行 commit
+ oco config set OCO_OMIT_SCOPE=true # 省略 scope
 ```
 
 4. 使用 oco 命令生成 commit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for an optional OpenCommit setting (OCO_OMIT_SCOPE) to omit scope in AI-generated commit messages, with a sample configuration command and placement in the OpenCommit usage docs. Documentation-only; no behavioral changes to the app.

* **Chores**
  * Adjusted PR title auto-labeling mapping so only "docs" (not "doc") maps to the "documentation" label, affecting label assignment for PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->